### PR TITLE
Added blogs homepages

### DIFF
--- a/src/Controller/Admin/ArticlesController.php
+++ b/src/Controller/Admin/ArticlesController.php
@@ -26,7 +26,7 @@ class ArticlesController extends AppController
         $this->Authorization->skipAuthorization();
 
         $this->paginate = [
-            'contain' => ['Users'],
+            'contain' => ['Users', 'Blogs'],
         ];
         $articles = $this->paginate($this->Articles);
 

--- a/src/Controller/ArticlesController.php
+++ b/src/Controller/ArticlesController.php
@@ -45,6 +45,8 @@ class ArticlesController extends AppController
             return $this->redirect($dr);
         }
 
+        $homePage = $articlesManager->getHomePageContent($this->request);
+
         $this->paginate = [
             'contain' => ['Users', 'Blogs'],
             'order' => ['Articles.created' => 'DESC'],
@@ -53,7 +55,7 @@ class ArticlesController extends AppController
 
         $articles = $articlesManager->getAll($this->request, $this);
 
-        $this->set(compact('articles'));
+        $this->set(compact('articles', 'homePage'));
     }
 
     /**

--- a/src/Services/ArticlesManagerService.php
+++ b/src/Services/ArticlesManagerService.php
@@ -7,6 +7,7 @@ use Cake\Http\ServerRequest;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
+use Cake\Utility\Text;
 use MeowBlog\Controller\AppController;
 use MeowBlog\Model\Entity\Article;
 use MeowBlog\Model\Entity\ArticleType;
@@ -106,5 +107,23 @@ class ArticlesManagerService implements ArticlesManagerServiceInterface
         $savedArticle = $this->articles->save($article);
 
         return $savedArticle;
+    }
+
+    public function getHomePageContent(ServerRequest $request): ?string
+    {
+        /** @var \MeowBlog\Model\Table\ArticlesTable $articleTable */
+        $articleTable = $this->articles;
+
+        /** @var \Cake\ORM\Query $q */
+        $q = $articleTable->findBySlug(Text::slug($request->getUri()->getHost()))->where([
+            'Blogs.domain' => $request->getUri()->getHost(),
+            'Articles.article_type' => ArticleType::Page->value,
+            'Articles.published' => 1,
+        ]);
+
+        /** @var \MeowBlog\Model\Entity\Article $savedArticle */
+        $article = $q->contain(['Blogs'])->first();
+
+        return $article ? $article->body : null;
     }
 }

--- a/src/Services/ArticlesManagerServiceInterface.php
+++ b/src/Services/ArticlesManagerServiceInterface.php
@@ -40,4 +40,13 @@ interface ArticlesManagerServiceInterface
      * @return \MeowBlog\Model\Entity\Article|false
      */
     public function saveToDatabase(Article $article, ServerRequest $request): Article | false;
+
+    /**
+     * Return content of the homepage articles
+     * Home-page articles are articles that have title matched with the blog domain
+     *
+     * @param ServerRequest $request
+     * @return string|null
+     */
+    public function getHomePageContent(ServerRequest $request): ?string;
 }

--- a/templates/Admin/Articles/index.php
+++ b/templates/Admin/Articles/index.php
@@ -18,7 +18,6 @@ use MeowBlog\Model\Entity\ArticleType;
                     <th>
                         <?= $this->Paginator->sort('title') ?>
                     </th>
-                    <th><?= $this->Paginator->sort('slug') ?></th>
                     <th><?= $this->Paginator->sort('published') ?></th>
                     <th><?= $this->Paginator->sort('modified') ?></th>
                     <th class="actions"><?= __('Actions') ?></th>
@@ -27,13 +26,23 @@ use MeowBlog\Model\Entity\ArticleType;
             <tbody>
                 <?php foreach ($articles as $article): ?>
                 <tr>
-                    <td><td><?= $this->Number->format($article->id) ?></td></td>
+                    <td><?= $this->Number->format($article->id) ?></td>
                     <td>
-                        <?= h($article->title) ?>
+                        <?= $article->blog->title ?> /
+                        <?php if ($article->title == $article->blog->domain) : ?>
+                        <span data-tooltip="<?= __('This Is Homepage of {0} blog', $article->blog->title) ?>">
+                            <?= h($article->title) ?>
+                        </span>
+                        <?php else : ?>
+                            <?= h($article->title) ?>
+                        <?php endif; ?>
                         <mark><?= ArticleType::from($article->article_type)->name ?></mark>
                     </td>
-                    <td><?= h($article->slug) ?></td>
-                    <td><?= h($article->published) ?></td>
+                    <td>
+                        <span data-tooltip="<?= $article->slug ?>">
+                            <?= $article->published ? __('Yes') : __('No') ?>
+                        </span>
+                    </td>
                     <td><?= h($article->modified) ?></td>
                     <td class="actions">
                         <?= $this->Html->link(__('View'), ['action' => 'view', $article->id]) ?>

--- a/templates/Admin/Articles/view.php
+++ b/templates/Admin/Articles/view.php
@@ -19,7 +19,9 @@ use MeowBlog\Model\Entity\ArticleType;
     </aside>
     <div class="column-responsive column-80">
         <div class="articles view content">
-            <h3><?= h($article->title) ?> <mark><?= ArticleType::from($article->article_type)->name ?></mark></h3>
+            <h3><?= h($article->title) ?> 
+                <mark><?= $article->title == $article->blog->domain ? __('Home Page of {0}', $article->blog->title) : ArticleType::from($article->article_type)->name ?></mark>
+            </h3>
             <table>
                 <tr>
                     <th><?= __('User') ?></th>

--- a/templates/Articles/index.php
+++ b/templates/Articles/index.php
@@ -6,6 +6,9 @@
  */
 ?>
 <div class="articles index content">
+
+    <?= $homePage ? $this->Markdown->parse($homePage) : '' ?>
+
     <h3><?= __('Latest Articles') ?></h3>
     <div style="margin-bottom: 1em;">
     <?php foreach ($articles as $article): ?>


### PR DESCRIPTION
<!---

**PLEASE NOTE:**

This is only a issue tracker for issues related to the CakePHP Application Skeleton.
For CakePHP Framework issues please use this [issue tracker](https://github.com/cakephp/cakephp/issues).

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) guidelines when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->

Allows to create homepage content per blog. Home-pages are article type page that have the title same as blog domain of blog to which they belong
